### PR TITLE
#8 Configured MySQL Connection

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,7 @@
-
+spring.datasource.url=jdbc:mysql://localhost:3306/appointment_setting
+spring.datasource.username=root
+spring.datasource.password=password
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
Closes #8 
 updated only application.properties in the backend project.
What changed:
•added MySQL datasource URL for local MySQL on localhost:3306 using database appointment_setting
•added datasource username root
•added datasource password password
•added MySQL JDBC driver class com.mysql.cj.jdbc.Driver
•set JPA ddl-auto to update
•enabled SQL logging with spring.jpa.show-sql=true
•set the Hibernate dialect to org.hibernate.dialect.MySQL8Dialect
What did not change:
•no other files were modified
•no dependencies were added•
•no package structure or Java classes were changed
•no controllers, services, repositories, entities, DTOs, exceptions, tests, or config classes were added
Purpose:
•the backend is now minimally configured to connect to MySQL and is ready for adding JPA entities later without reworking the database setup.