### PR TITLE
#15 Seed Topics

### DIFF
--- a/backend/src/main/java/com/ucm/appointmentsetting/config/DataInitializer.java
+++ b/backend/src/main/java/com/ucm/appointmentsetting/config/DataInitializer.java
@@ -1,0 +1,40 @@
+package com.ucm.appointmentsetting.config;
+
+import com.ucm.appointmentsetting.entity.Topic;
+import com.ucm.appointmentsetting.repository.TopicRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class DataInitializer {
+
+    @Bean
+    CommandLineRunner seedTopics(TopicRepository topicRepository) {
+        return args -> {
+            if (topicRepository.count() > 0) {
+                return;
+            }
+
+            Topic loans = new Topic();
+            loans.setName("Loans");
+            loans.setDescription("Support for personal, auto, and home loan questions.");
+
+            Topic creditCards = new Topic();
+            creditCards.setName("Credit Cards");
+            creditCards.setDescription("Help with applications, limits, payments, and card services.");
+
+            Topic newAccounts = new Topic();
+            newAccounts.setName("New Accounts");
+            newAccounts.setDescription("Assistance with opening checking, savings, and related accounts.");
+
+            Topic fraudSupport = new Topic();
+            fraudSupport.setName("Fraud Support");
+            fraudSupport.setDescription("Guidance for suspicious transactions, blocked cards, and account security.");
+
+            topicRepository.saveAll(List.of(loans, creditCards, newAccounts, fraudSupport));
+        };
+    }
+}


### PR DESCRIPTION
Closes #15 
Update Summary

Added one backend-only startup seeding class:
DataInitializer.java

What It Does
Registers a CommandLineRunner bean
Injects TopicRepository
Checks whether the topics table is empty using topicRepository.count()
Returns immediately if any topics already exist
Inserts four initial topics only when the table is empty:
Loans
Credit Cards
New Accounts
Fraud Support
What Did Not Change
No frontend files
No other backend files
No entities, repositories, controllers, services, DTOs, exceptions, or tests
No SQL seed files
No changes to:
build.gradle
settings.gradle
application.properties
main application class
Result

The backend now seeds initial Topic data programmatically at startup, running only once when the table is empty.