### PR TITLE
#17 Branch-Topic Mapping

### DIFF
--- a/backend/src/main/java/com/ucm/appointmentsetting/config/DataInitializer.java
+++ b/backend/src/main/java/com/ucm/appointmentsetting/config/DataInitializer.java
@@ -8,7 +8,11 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Configuration
 public class DataInitializer {
@@ -69,6 +73,46 @@ public class DataInitializer {
             north.setZip("64155");
 
             branchRepository.saveAll(List.of(downtown, south, north));
+        };
+    }
+
+    @Bean
+    CommandLineRunner seedBranchTopics(TopicRepository topicRepository, BranchRepository branchRepository) {
+        return args -> {
+            if (topicRepository.count() == 0 || branchRepository.count() == 0) {
+                return;
+            }
+
+            Map<String, Topic> topicsByName = topicRepository.findAll()
+                    .stream()
+                    .collect(Collectors.toMap(Topic::getName, Function.identity()));
+
+            Map<String, Branch> branchesByName = branchRepository.findAll()
+                    .stream()
+                    .collect(Collectors.toMap(Branch::getName, Function.identity()));
+
+            Topic loans = topicsByName.get("Loans");
+            Topic creditCards = topicsByName.get("Credit Cards");
+            Topic newAccounts = topicsByName.get("New Accounts");
+            Topic fraudSupport = topicsByName.get("Fraud Support");
+
+            Branch downtown = branchesByName.get("Downtown Branch");
+            if (downtown != null && loans != null && creditCards != null) {
+                downtown.setTopics(new HashSet<>(List.of(loans, creditCards)));
+                branchRepository.save(downtown);
+            }
+
+            Branch south = branchesByName.get("South Branch");
+            if (south != null && creditCards != null && newAccounts != null) {
+                south.setTopics(new HashSet<>(List.of(creditCards, newAccounts)));
+                branchRepository.save(south);
+            }
+
+            Branch north = branchesByName.get("North Branch");
+            if (north != null && newAccounts != null && fraudSupport != null) {
+                north.setTopics(new HashSet<>(List.of(newAccounts, fraudSupport)));
+                branchRepository.save(north);
+            }
         };
     }
 }


### PR DESCRIPTION
Closes #17 
 fixed the actual backend startup/code issues that were blocking bootRun.
What was changed:
•updated AppointmentSettingApplication.java
◦removed the exclusions for DataSourceAutoConfiguration and HibernateJpaAutoConfiguration
◦this allowed Spring Data JPA to initialize and detect repository beans like TopicRepository
•updated DataInitializer.java
◦extended it to seed topics, branches, and branch-topic relationships
◦removed the lazy-loading check branch.getTopics().isEmpty() that was causing LazyInitializationException
◦kept relationship seeding on the owning Branch side
◦made the topic lookup null-safe before assigning relationships
What was not changed:
•no frontend files
•no repositories
•no entity classes for this fix step
•no build.gradle, settings.gradle, or main app config beyond the application class fix
What the current status means:
•the original bean wiring failure is fixed
•the lazy-loading failure is fixed
•MySQL connection is working
•the latest failure you saw is not a code problem
◦it happened because port 8080 was already in use by an already-running Java process (PID 636) from the prior successful run
So at this point:
•code-level startup issues are resolved
•the remaining issue is only a local port conflict when trying to start a second copy of the app

<img width="788" height="900" alt="Screenshot 2026-03-24 at 10 05 48 AM" src="https://github.com/user-attachments/assets/ebd9d9fc-7562-4299-a0bd-3060262611f6" />
