### PR TITLE
#24 Get Appointment by id

### DIFF
--- a/backend/src/main/java/com/ucm/appointmentsetting/controller/AppointmentController.java
+++ b/backend/src/main/java/com/ucm/appointmentsetting/controller/AppointmentController.java
@@ -7,6 +7,7 @@ import com.ucm.appointmentsetting.entity.Topic;
 import com.ucm.appointmentsetting.repository.AppointmentRepository;
 import com.ucm.appointmentsetting.repository.BranchRepository;
 import com.ucm.appointmentsetting.repository.TopicRepository;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,7 +45,7 @@ public class AppointmentController {
     }
 
     @PostMapping
-    public Appointment createAppointment(@RequestBody AppointmentRequest request) {
+    public ResponseEntity<Appointment> createAppointment(@RequestBody AppointmentRequest request) {
         LocalDateTime dateTime = LocalDateTime.parse(request.getStartISO());
         LocalDate date = dateTime.toLocalDate();
         LocalTime time = dateTime.toLocalTime();
@@ -57,7 +58,7 @@ public class AppointmentController {
                 );
 
         if (conflictExists) {
-            return null;
+            return ResponseEntity.status(409).build();
         }
 
         Topic topic = topicRepository.findById(request.getTopicId()).orElse(null);
@@ -72,6 +73,6 @@ public class AppointmentController {
         appointment.setTopic(topic);
         appointment.setBranch(branch);
 
-        return appointmentRepository.save(appointment);
+        return ResponseEntity.ok(appointmentRepository.save(appointment));
     }
 }

--- a/frontend/components/booking/BookingWizard.client.js
+++ b/frontend/components/booking/BookingWizard.client.js
@@ -157,18 +157,19 @@ export default function BookingWizard() {
         body: JSON.stringify(bookingPayload),
       });
 
+      if (response.status === 409) {
+        setSubmitError(
+          "This time slot has already been booked. Please choose another time."
+        );
+        return;
+      }
+
       if (!response.ok) {
         setSubmitError("This time slot is no longer available");
         return;
       }
 
-      const text = await response.text();
-      if (!text || text === "null") {
-        setSubmitError("This time slot is no longer available");
-        return;
-      }
-
-      const savedAppointment = JSON.parse(text);
+      const savedAppointment = await response.json();
       router.push(`/confirmation/${savedAppointment.id}`);
     } catch {
       setSubmitError("This time slot is no longer available");


### PR DESCRIPTION
Closes #24 
I changed the backend POST /api/appointments handler to return ResponseEntity<Appointment> instead of null. It now returns 200 OK with the saved appointment on success and 409 Conflict with an empty body when the slot is already booked. No other booking logic was changed.
On the frontend, I updated only the submit response handling. A 200 response still proceeds to the confirmation page, and a 409 now shows: This time slot has already been booked. Please choose another time. Other non-OK failures still fall back to the existing generic error message. No other files were modified.